### PR TITLE
Fix a breaking change with 0.47.0

### DIFF
--- a/android/src/main/java/com/wog/videoplayer/VideoPlayerPackage.java
+++ b/android/src/main/java/com/wog/videoplayer/VideoPlayerPackage.java
@@ -20,7 +20,6 @@ public class VideoPlayerPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new VideoPlayerModule(reactContext));
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
createJSModules is removed in 0.47.0. Ref https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8