### PR TITLE
Allow proper linking for any app.

### DIFF
--- a/ios/RNVideoPlayer.xcodeproj/project.pbxproj
+++ b/ios/RNVideoPlayer.xcodeproj/project.pbxproj
@@ -224,7 +224,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../../../ios/Freekik/**",
+					"$(SRCROOT)/../../../ios/**",
 					"$(SRCROOT)/../../react-native/React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
@@ -239,7 +239,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../../../ios/Freekik/**",
+					"$(SRCROOT)/../../../ios/**",
 					"$(SRCROOT)/../../react-native/React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";

--- a/ios/RNVideoPlayer.xcodeproj/project.pbxproj
+++ b/ios/RNVideoPlayer.xcodeproj/project.pbxproj
@@ -224,7 +224,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../../../ios/HuntersLog/**",
+					"$(SRCROOT)/../../../ios/Freekik/**",
 					"$(SRCROOT)/../../react-native/React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
@@ -239,7 +239,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../../../ios/HuntersLog/**",
+					"$(SRCROOT)/../../../ios/Freekik/**",
 					"$(SRCROOT)/../../react-native/React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
Instead of adding header search path for the app name which we don't know in that scope, recursively search the iOS folder for the AppDelegate.h file.