### PR TITLE
removed unused AppDelegate.h

### DIFF
--- a/ios/RNVideoPlayer/RNVideoPlayer.h
+++ b/ios/RNVideoPlayer/RNVideoPlayer.h
@@ -6,7 +6,6 @@
 //  Copyright © 2016 DC5 Admin (MACMINI032). All rights reserved.
 //
 
-#import "AppDelegate.h"
 #import "RCTBridge.h"
 #import <Foundation/Foundation.h>
 #import <AVKit/AVKit.h>


### PR DESCRIPTION
Fix for #26.

The AppDelegate.h is not used and for swift projects without an AppDelegate.h it will throw an error. 