### PR TITLE
Get the rootViewController without casting to AppDelegate

### DIFF
--- a/ios/RNVideoPlayer/RNVideoPlayer.h
+++ b/ios/RNVideoPlayer/RNVideoPlayer.h
@@ -6,7 +6,6 @@
 //  Copyright © 2016 DC5 Admin (MACMINI032). All rights reserved.
 //
 
-#import "AppDelegate.h"
 #import "RCTBridge.h"
 #import <Foundation/Foundation.h>
 #import <AVKit/AVKit.h>

--- a/ios/RNVideoPlayer/RNVideoPlayer.m
+++ b/ios/RNVideoPlayer/RNVideoPlayer.m
@@ -17,8 +17,8 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(showVideoPlayer: (NSString*) url)
 {
     self.videoURL = [NSURL URLWithString:url];
-    AppDelegate *delegate = (AppDelegate *)[[UIApplication sharedApplication] delegate];
-
+    UIViewController *rootViewController = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
+    
     AVPlayer *player = [AVPlayer playerWithURL:self.videoURL];
     self.playerViewController = [AVPlayerViewController new];
     _playerViewController.player = player;
@@ -27,8 +27,8 @@ RCT_EXPORT_METHOD(showVideoPlayer: (NSString*) url)
 
     dispatch_async(dispatch_get_main_queue(), ^{
 
-        [delegate.window.rootViewController.view addSubview:self.playerViewController.view];
-        [delegate.window.rootViewController presentViewController:self.playerViewController animated:YES completion:nil];
+        [rootViewController.view addSubview:self.playerViewController.view];
+        [rootViewController presentViewController:self.playerViewController animated:YES completion:nil];
 
     });
 


### PR DESCRIPTION
The AppDelegate.h is only used so that we can grab the rootViewController, but Alexander Voityuk
@a-voityuk has shown how to do this in

https://github.com/a-voityuk/react-native-native-video-player/commit/94fae9b517d67282bc829eeef494106e016458f4#diff-cab10c893122a0d34bad65887e67ff15

This would resolve #26 
and avoid any of the steps needed in #4 

