### PR TITLE
Rename the module to match the JS code name of VideoPlayerManager

### DIFF
--- a/ios/RNVideoPlayer/RNVideoPlayer.m
+++ b/ios/RNVideoPlayer/RNVideoPlayer.m
@@ -12,13 +12,13 @@
 
 @synthesize bridge = _bridge;
 
-RCT_EXPORT_MODULE();
+RCT_EXPORT_MODULE(VideoPlayerManager);
 
 RCT_EXPORT_METHOD(showVideoPlayer: (NSString*) url)
 {
     self.videoURL = [NSURL URLWithString:url];
     UIViewController *rootViewController = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
-    
+
     AVPlayer *player = [AVPlayer playerWithURL:self.videoURL];
     self.playerViewController = [AVPlayerViewController new];
     _playerViewController.player = player;


### PR DESCRIPTION
Fix for #31 
